### PR TITLE
Fix: Test type ordernumber

### DIFF
--- a/src/Pixidos/GPWebPay/Operation.php
+++ b/src/Pixidos/GPWebPay/Operation.php
@@ -137,8 +137,8 @@ class Operation
 		if (strlen($orderNumber) > 15) {
 			throw new InvalidArgumentException('ORDERNUMBER max. length is 15! ' . strlen($orderNumber) . ' given');
 		}
-		if (!is_int($orderNumber)) {
-			throw new InvalidArgumentException('ORDERNUMBER must by type of int ' . gettype($orderNumber) . ' given');
+		if (!is_numeric($orderNumber)) {
+			throw new InvalidArgumentException('ORDERNUMBER must by type of numeric ' . gettype($orderNumber) . ' given');
 		}
 		$this->orderNumber = $orderNumber;
 	}


### PR DESCRIPTION
- Integer has max 10 length (in 32 bit).
- Numeric test is OK for GPWebPay
