### PR TITLE
Fix: verify response if RESULTTEXT is empty

### DIFF
--- a/src/Pixidos/GPWebPay/Response.php
+++ b/src/Pixidos/GPWebPay/Response.php
@@ -50,7 +50,9 @@ class Response
             $this->params['MD'] = $md;
         $this->params['PRCODE'] = (int)$prcode;
         $this->params['SRCODE'] = (int)$srcode;
-        $this->params['RESULTTEXT'] = $resulttext;
+        if ( ! empty($resulttext)) {
+		    $this->params['RESULTTEXT'] = $resulttext;
+        }
         $this->digest = $digest;
         $this->digest1 = $digest1;
         $this->gatewayKey = $gatewayKey;


### PR DESCRIPTION
- If RESULTTEXT is empty, we cannot include it to verify response. There is problem, digest not match