### PR TITLE
Added catch for GPWebPayResultException

### DIFF
--- a/src/Pixidos/GPWebPay/Components/GPWebPayControl.php
+++ b/src/Pixidos/GPWebPay/Components/GPWebPayControl.php
@@ -12,6 +12,7 @@ use Nette\Application\UI;
 use Nette\Bridges\ApplicationLatte\Template;
 use Nette\ComponentModel\IContainer;
 use Pixidos\GPWebPay\Exceptions\GPWebPayException;
+use Pixidos\GPWebPay\Exceptions\GPWebPayResultException;
 use Pixidos\GPWebPay\Intefaces\IOperation;
 use Pixidos\GPWebPay\Intefaces\IProvider;
 use Pixidos\GPWebPay\Intefaces\IRequest;
@@ -116,7 +117,11 @@ class GPWebPayControl extends UI\Control
             $this->provider->verifyPaymentResponse($response);
         } catch (GPWebPayException $e) {
             $this->errorHandler($e);
-            
+
+            return;
+        } catch (GPWebPayResultException $e) {
+            $this->errorHandler(new GPWebPayException($e->getMessage()));
+
             return;
         }
         


### PR DESCRIPTION
provider verify throw GPWebPayResultException too, so I added to catch.

For test: 
PRCODE: 35 
SRCODE: 0

its session expired.

Thanks @ondraondra81 